### PR TITLE
fix: Error on invalid record type

### DIFF
--- a/src/nuis/record/RecordFactory.cxx
+++ b/src/nuis/record/RecordFactory.cxx
@@ -1,4 +1,5 @@
 #include "nuis/record/RecordFactory.h"
+#include "nuis/record/exceptions.h"
 
 #ifdef NUISANCE_USE_BOOSTDLL
 #include "boost/dll/import.hpp"
@@ -68,6 +69,10 @@ IRecordPtr TryAllKnownRecordPlugins(YAML::Node const &cfg) {
     return rec;
   }
 #endif
+
+  NUIS_LOG_CRITICAL("record plugin {} is not enabled, please enable and recompile",
+                    type_name);
+  throw UnknownRecordPlugin;
 
   return nullptr;
 }

--- a/src/nuis/record/RecordFactory.cxx
+++ b/src/nuis/record/RecordFactory.cxx
@@ -70,9 +70,10 @@ IRecordPtr TryAllKnownRecordPlugins(YAML::Node const &cfg) {
   }
 #endif
 
-  NUIS_LOG_CRITICAL("record plugin {} is not enabled, please enable and recompile",
+  NUIS_LOG_CRITICAL("record plugin {} is not enabled or is unknown, "
+                    "please enable and recompile",
                     type_name);
-  throw UnknownRecordPlugin;
+  throw UnknownRecordPlugin();
 
   return nullptr;
 }

--- a/src/nuis/record/exceptions.h
+++ b/src/nuis/record/exceptions.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "nuis/except.h"
+
+namespace nuis {
+DECLARE_NUISANCE_EXCEPT(UnknownRecordPlugin);
+} // namespace nuis


### PR DESCRIPTION
# Pull request description
This resolves #57

## Changes or fixes
Provide an error message and throw an error when the record type is either invalid or not enabled.
This is better than an obscure segfault, especially since in a jupyter notebook the user is only informed that the notebook failed.