### PR TITLE
fix: Use "fmt" instead of "spdlog/bundled/fmt"

### DIFF
--- a/examples/c++/nuis-hepdata-rec.cxx
+++ b/examples/c++/nuis-hepdata-rec.cxx
@@ -4,8 +4,8 @@
 
 #include "yaml-cpp/yaml.h"
 
-#include "spdlog/fmt/bundled/core.h"
-#include "spdlog/fmt/bundled/ranges.h"
+#include "fmt/core.h"
+#include "fmt/ranges.h"
 
 using namespace nuis;
 

--- a/src/nuis/binning/Binning.cxx
+++ b/src/nuis/binning/Binning.cxx
@@ -4,7 +4,7 @@
 
 #include "nuis/log.txx"
 
-#include "spdlog/fmt/bundled/ranges.h"
+#include "fmt/ranges.h"
 
 #include <cmath>
 

--- a/src/nuis/binning/BinningFactories.cxx
+++ b/src/nuis/binning/BinningFactories.cxx
@@ -3,7 +3,7 @@
 #include "nuis/binning/log_bin_edges.txx"
 #include "nuis/binning/utility.h"
 
-#include "spdlog/fmt/bundled/ranges.h"
+#include "fmt/ranges.h"
 
 namespace nuis {
 

--- a/src/nuis/binning/SingleExtent.cxx
+++ b/src/nuis/binning/SingleExtent.cxx
@@ -1,6 +1,6 @@
 #include "nuis/binning/SingleExtent.h"
 
-#include "spdlog/fmt/bundled/core.h"
+#include "fmt/core.h"
 
 namespace nuis {
 

--- a/src/nuis/binning/utility.cxx
+++ b/src/nuis/binning/utility.cxx
@@ -3,7 +3,7 @@
 
 #include "nuis/log.txx"
 
-#include "spdlog/fmt/bundled/ranges.h"
+#include "fmt/ranges.h"
 
 #include <cmath>
 

--- a/src/nuis/convert/ROOT.h
+++ b/src/nuis/convert/ROOT.h
@@ -16,8 +16,8 @@
 #include "TH2.h"
 #include "TH3.h"
 
-#include "spdlog/fmt/bundled/core.h"
-#include "spdlog/fmt/bundled/ranges.h"
+#include "fmt/core.h"
+#include "fmt/ranges.h"
 
 // This should be header-only so that ROOT is not required by NUISANCE core
 //   but is available for user scripts that want to write out ROOT histograms

--- a/src/nuis/convert/misc.cxx
+++ b/src/nuis/convert/misc.cxx
@@ -2,8 +2,8 @@
 
 #include "nuis/binning/utility.h"
 
-#include "spdlog/fmt/bundled/core.h"
-#include "spdlog/fmt/bundled/ranges.h"
+#include "fmt/core.h"
+#include "fmt/ranges.h"
 
 namespace nuis {
 

--- a/src/nuis/convert/yaml.cxx
+++ b/src/nuis/convert/yaml.cxx
@@ -1,6 +1,6 @@
 #include "nuis/convert/yaml.h"
 
-#include "spdlog/fmt/bundled/core.h"
+#include "fmt/core.h"
 
 // independent_variables:
 // - header: {name: Leading dilepton PT, units: GEV}

--- a/src/nuis/eventframe/EventFrame.cxx
+++ b/src/nuis/eventframe/EventFrame.cxx
@@ -1,7 +1,7 @@
 #include "nuis/eventframe/EventFrame.h"
 
-#include "spdlog/fmt/bundled/core.h"
-#include "spdlog/fmt/bundled/ranges.h"
+#include "fmt/core.h"
+#include "fmt/ranges.h"
 
 #include "nuis/except.h"
 #include "nuis/log.txx"

--- a/src/nuis/eventframe/EventFrameGen.cxx
+++ b/src/nuis/eventframe/EventFrameGen.cxx
@@ -3,8 +3,8 @@
 #include "NuHepMC/ReaderUtils.hxx"
 #include "NuHepMC/UnitsUtils.hxx"
 
-#include "spdlog/fmt/bundled/chrono.h"
-#include "spdlog/fmt/bundled/ranges.h"
+#include "fmt/chrono.h"
+#include "fmt/ranges.h"
 
 #include "nuis/log.txx"
 

--- a/src/nuis/eventframe/utility.h
+++ b/src/nuis/eventframe/utility.h
@@ -9,7 +9,7 @@
 #include "arrow/api.h"
 #endif
 
-#include "spdlog/fmt/bundled/core.h"
+#include "fmt/core.h"
 
 #include <map>
 #include <sstream>

--- a/src/nuis/eventinput/EventSourceFactory.cxx
+++ b/src/nuis/eventinput/EventSourceFactory.cxx
@@ -15,8 +15,8 @@
 
 #include "yaml-cpp/yaml.h"
 
-#include "spdlog/fmt/bundled/core.h"
-#include "spdlog/fmt/bundled/ranges.h"
+#include "fmt/core.h"
+#include "fmt/ranges.h"
 
 #include <regex>
 

--- a/src/nuis/histframe/BinnedValues.cxx
+++ b/src/nuis/histframe/BinnedValues.cxx
@@ -9,7 +9,7 @@
 
 #include "nuis/log.txx"
 
-#include "spdlog/fmt/bundled/ranges.h"
+#include "fmt/ranges.h"
 
 namespace nuis {
 

--- a/src/nuis/histframe/HistFrame.cxx
+++ b/src/nuis/histframe/HistFrame.cxx
@@ -4,7 +4,7 @@
 
 #include "nuis/log.txx"
 
-#include "spdlog/fmt/bundled/ranges.h"
+#include "fmt/ranges.h"
 
 DECLARE_NUISANCE_EXCEPT(InvalidColumnAccess);
 

--- a/src/nuis/histframe/frame_fill.h
+++ b/src/nuis/histframe/frame_fill.h
@@ -8,8 +8,8 @@
 
 #include "nuis/log.txx"
 
-#include "spdlog/fmt/bundled/core.h"
-#include "spdlog/fmt/bundled/ranges.h"
+#include "fmt/core.h"
+#include "fmt/ranges.h"
 
 #ifdef NUIS_ARROW_ENABLED
 #include "arrow/api.h"

--- a/src/nuis/histframe/utility.cxx
+++ b/src/nuis/histframe/utility.cxx
@@ -4,7 +4,7 @@
 #include "nuis/binning/exceptions.h"
 #include "nuis/binning/utility.h"
 
-#include "spdlog/fmt/bundled/ranges.h"
+#include "fmt/ranges.h"
 
 #include "nuis/log.txx"
 

--- a/src/nuis/python/pyRecord.cxx
+++ b/src/nuis/python/pyRecord.cxx
@@ -14,7 +14,7 @@
 #include "pybind11/eigen.h"
 #include "pybind11/functional.h"
 
-#include "spdlog/fmt/bundled/core.h"
+#include "fmt/core.h"
 
 #ifdef NUIS_ARROW_ENABLED
 #include "arrow/python/pyarrow.h"

--- a/src/nuis/record/IAnalysis.cxx
+++ b/src/nuis/record/IAnalysis.cxx
@@ -1,6 +1,6 @@
 #include "nuis/record/IAnalysis.h"
 
-#include "spdlog/fmt/bundled/core.h"
+#include "fmt/core.h"
 
 namespace nuis {
 

--- a/src/nuis/record/LikelihoodFunctions.h
+++ b/src/nuis/record/LikelihoodFunctions.h
@@ -2,7 +2,7 @@
 
 #include "nuis/record/Comparison.h"
 
-#include "spdlog/fmt/bundled/core.h"
+#include "fmt/core.h"
 
 #include "Eigen/Dense"
 

--- a/src/nuis/record/RecordFactory.cxx
+++ b/src/nuis/record/RecordFactory.cxx
@@ -9,7 +9,7 @@
 
 #include "yaml-cpp/yaml.h"
 
-#include "spdlog/fmt/bundled/core.h"
+#include "fmt/core.h"
 
 #include "nuis/env.h"
 #include "nuis/log.txx"

--- a/src/nuis/record/SingleDistributionAnalysis.h
+++ b/src/nuis/record/SingleDistributionAnalysis.h
@@ -7,7 +7,7 @@
 #include "nuis/histframe/frame_fill.h"
 #include "nuis/histframe/utility.h"
 
-#include "spdlog/fmt/bundled/core.h"
+#include "fmt/core.h"
 
 namespace nuis {
 

--- a/src/nuis/record/SingleFluxAnalysis.h
+++ b/src/nuis/record/SingleFluxAnalysis.h
@@ -9,7 +9,7 @@
 
 #include "NuHepMC/UnitsUtils.hxx"
 
-#include "spdlog/fmt/bundled/core.h"
+#include "fmt/core.h"
 
 namespace nuis {
 

--- a/src/nuis/record/plugins/HEPDataRecordPlugin.cxx
+++ b/src/nuis/record/plugins/HEPDataRecordPlugin.cxx
@@ -16,8 +16,8 @@
 
 #include "NuHepMC/ReaderUtils.hxx"
 
-#include "spdlog/fmt/bundled/core.h"
-#include "spdlog/fmt/bundled/ranges.h"
+#include "fmt/core.h"
+#include "fmt/ranges.h"
 
 #ifdef NUISANCE_USE_BOOSTDLL
 #include "boost/dll/alias.hpp"

--- a/src/nuis/response/FramedResponse.txx
+++ b/src/nuis/response/FramedResponse.txx
@@ -4,7 +4,7 @@
 
 #include "nuis/except.h"
 
-#include "spdlog/fmt/bundled/core.h"
+#include "fmt/core.h"
 
 namespace nuis {
 


### PR DESCRIPTION
# Pull request description
Closes #56.

## Changes or fixes
Ensures that if the user has an externally built fmt from spdlog that it doesn't attempt to use the bundled headers.